### PR TITLE
Oak audit remediations

### DIFF
--- a/contracts/astrozap/src/contract.rs
+++ b/contracts/astrozap/src/contract.rs
@@ -73,7 +73,7 @@ fn enter(
     // sent alone with `info.funds`
     let deposit_msgs = handle_deposits(
         &deposits,
-        &info.funds.into(),
+        &mut info.funds.into(),
         &info.sender,
         &env.contract.address,
     )?;

--- a/contracts/astrozap/src/contract_tests.rs
+++ b/contracts/astrozap/src/contract_tests.rs
@@ -214,6 +214,35 @@ fn should_reject_missing_deposit() {
 }
 
 #[test]
+fn should_reject_extra_deposit() {
+    let mut deps = setup_test();
+
+    let msg = ExecuteMsg::Enter {
+        pair: String::from("luna_ust_pair"),
+        deposits: AssetList::from(vec![Asset::native("uluna", 12345u128)]).into(),
+        minimum_received: None,
+    };
+    // User claims to deposit 12345 uluna, but also deposit more 
+    let actual_deposits = &[
+        Coin::new(12345, "uluna"),
+        Coin::new(69420, "uusd"),
+        Coin::new(88888, "uatom"),
+    ];
+    let err = execute(
+        deps.as_mut(),
+        mock_env(),
+        mock_info("alice", actual_deposits),
+        msg.clone(),
+    );
+    assert_eq!(
+        err,
+        Err(StdError::generic_err(
+            "extra deposit received: native:uusd:69420,native:uatom:88888"
+        ))
+    );
+}
+
+#[test]
 fn should_enter_native_native_pool() {
     let mut deps = setup_test();
 


### PR DESCRIPTION
Our responses to each of the issues raised in the audit report:

## 3. Leftover amount after providing liquidity is not refunded

We overhauled the management of assets throughout the tx life cycle to avoid leftover not being refunded. 

Specifically, we create a variable `cache.assets` of `cw_asset::AssetList` type to track the list of available assets owned by the user that is under custody by this contract.

* We initialize the list from the `deposit` parameter provided by the user ([`contract.rs#L104`](https://github.com/astroport-fi/astro-zap/blob/oak-audit/contracts/astrozap/src/contract.rs#L104))
* If a swap is to be executed, we deduct the asset to be offered from list ([`helpers.rs#L181`](https://github.com/astroport-fi/astro-zap/blob/oak-audit/contracts/astrozap/src/helpers.rs#L181))
* Once the swap is completed, we add the returned asset to the list ([`contract.rs#L242`](https://github.com/astroport-fi/astro-zap/blob/oak-audit/contracts/astrozap/src/contract.rs#L242))
* If a liquidity provision is to be executed, we deduct the assets to be provided from the list ([`helpers.rs#L215`](https://github.com/astroport-fi/astro-zap/blob/oak-audit/contracts/astrozap/src/helpers.rs#L215))
* Once the liquidity provision is completed, we add the minted LP tokens to the list ([`contract.rs#L287`](https://github.com/astroport-fi/astro-zap/blob/oak-audit/contracts/astrozap/src/contract.rs#L287))
* In the end, we refund all assets in the list to the user ([`contract.rs#L104`](https://github.com/astroport-fi/astro-zap/blob/oak-audit/contracts/astrozap/src/contract.rs#L104))

This mechanism ensures we accurately track what assets owned by the user are under custody by this contract, and refund _all_ of them to the user at the end of the tx lifecycle.

## 6. Extra funds sent to AstroZap contract are lost

We implemented [a check](https://github.com/astroport-fi/astro-zap/blob/oak-audit/contracts/astrozap/src/helpers.rs#L106) for this situation, with [the same mechanism as used in the Fields of Mars contract](https://github.com/mars-protocol/fields-of-mars/blob/v1.0.0-rc3/contracts/martian-field/src/execute.rs#L88).